### PR TITLE
Fix variable name typo

### DIFF
--- a/files/minishift-up.yml
+++ b/files/minishift-up.yml
@@ -7,7 +7,7 @@
     - role: chouseknecht.minishift-up-role
       minishift_repo: minishift/minishift 
       minishift_github_url: https://api.github.com/repos
-      minishit_release_tag_name: ""
+      minishift_release_tag_name: ""
       minishift_dest: /usr/local/bin  
       minishift_force_install: yes
       minishift_restart: yes 


### PR DESCRIPTION
The task that uses 'minishift_release_tag_name' is minishift-up-role/tasks/get_ms_assets.yml and it would prefer that minishift is spelled correctly.