### PR TITLE
Fix the missing context when deploying minishift

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,4 @@ minishift_dest: /usr/local/bin
 openshift_client_dest: /usr/local/bin
 openshift_force_client_copy: yes 
 openshift_hostname: local.openshift
+openshift_default_context: myproject

--- a/tasks/Darwin_driver.yml
+++ b/tasks/Darwin_driver.yml
@@ -1,7 +1,7 @@
 # Darwin_driver.yml 
 
 - name: Check if docker-machine-driver-xhyve is installed
-  command: brew info --installed docker-machine-driver-xhyve
+  command: brew info docker-machine-driver-xhyve
   register: output
 
 - name: Install docker-machine-driver-xhyve 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
   when: not oc_client.stat.exists or openshift_force_client_copy
 
 - name: Switch the kube config context
-  shell: "{{ openshift_client_dest }}/oc config use-context /$(minishift ip | tr . -):8443/developer"
+  shell: "{{ openshift_client_dest }}/oc config use-context {{ openshift_default_context }}/$(minishift ip | tr . -):8443/developer"
 
 - name: Give cluster-admin to developer
   include_tasks: grant_admin.yml


### PR DESCRIPTION
I noticed that naming of default minishift projects is now prefixed with "myproject". I tried this locally and it works so I think it should be good to allow parametrization. I'm not sure when this change was introduced but it would be even better to detect the version and set the context prefix based on that.